### PR TITLE
Add queryGet.MAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ or match all objects that have a defined property _valid_ like `query.run(data, 
 
 ## queryGet
 
-If you only require values or pointers, use queryGet to receive an Array as result:
+If you only require values or pointers, use queryGet to receive an Array or Object as result:
 
 ```js
 	var queryGet = require("gson-query").get;
@@ -126,6 +126,8 @@ If you only require values or pointers, use queryGet to receive an Array as resu
 	var arrayOfJsonPointers = queryGet(data, "#/**/id", queryGet.POINTER);
 	// [arguments, arguments], where arguments = 0:value 1:object 2:key 3:jsonPointer
 	var arrayOfAllFourArguments = queryGet(data, "#/**/id", queryGet.ALL);
+	// {"#/..": value, "#/..": value}
+	var mapOfPointersAndData = queryGet(data, "#/**/id", queryGet.MAP);
 ```
 
 

--- a/lib/get.js
+++ b/lib/get.js
@@ -19,13 +19,14 @@ var query = require("./run");
  * @return {Array} containing result in specified format
  */
 function queryGet(obj, jsonPointer, type) {
-    var matches = [];
+    var matches = type === queryGet.MAP ? {} : [];
     var cb = getCbFactory(type, matches);
     query(obj, jsonPointer, cb);
     return matches;
 }
 
 queryGet.ALL = "all";
+queryGet.MAP = "map";
 queryGet.POINTER = "pointer";
 queryGet.VALUE = "value";
 
@@ -35,6 +36,11 @@ function getCbFactory(type, matches) {
         case queryGet.ALL:
             return function cbGetAll(value, key, obj, pointer) {
                 matches.push([obj[key], key, obj, pointer]);
+            };
+
+        case queryGet.MAP:
+            return function cbGetAll(value, key, obj, pointer) {
+                matches[pointer] = value;
             };
 
         case queryGet.POINTER:

--- a/test/unit/queryGet.test.js
+++ b/test/unit/queryGet.test.js
@@ -50,4 +50,16 @@ describe("queryGet", function () {
 		expect(result).to.have.length(4);
 		expect(result).to.contain("#/a", "#/b", "#/b/d", "#/c/e/f");
 	});
+
+	it("should return an object that maps pointers to their respective value", function () {
+		var result = queryGet(data, "#/**/*?needle:needle", queryGet.MAP);
+
+		expect(result).to.be.an("object");
+		expect(result).to.deep.equal({
+			"#/a": data.a,
+			"#/b": data.b,
+			"#/b/d": data.b.d,
+			"#/c/e/f": data.c.e.f
+		});
+	});
 });


### PR DESCRIPTION
Hi @sagold,

I thought about #1  a bit and came to the conclusion that neither dict() nor explode() work as a function name for me. json-pointer.dict() returns a dictionary of the input object independent of any pointers. And explode() implies the same for me. But the functionality this PR adds is merely a get() that returns an object instead of an array. So I implemented it this way. It was super simple and if you disagree about the change in the get() interface, it can be moved to a separate function easily. But then I would suggest a function name like map() or assoc().

Greetings,
Ben