### PR TITLE
fix: added support for merging items into an existing array

### DIFF
--- a/lib/set.ts
+++ b/lib/set.ts
@@ -67,6 +67,7 @@ function addToArray(
         getType(target[index]) === "object" &&
         getType(value) === "object"
     ) {
+        Object.assign(target[index], value);
         return [target[index], index, target, `${result[3]}/${index}}`];
     }
 
@@ -118,7 +119,10 @@ function create<T extends WorkingSet>(
         .map((r: QueryResult) => {
             const container = keyIsArray ? [] : {};
             const o = r[0];
-            if (Array.isArray(o)) {
+            const containerType = getType(container);
+            const itemType = getType(o[query]);
+
+            if (Array.isArray(o) && itemType !== containerType) {
                 return addToArray(r, query, container, force);
             }
             o[query] = o[query] || container;

--- a/test/unit/set.test.ts
+++ b/test/unit/set.test.ts
@@ -1,7 +1,7 @@
 /* eslint object-property-newline: 0 */
 import "mocha";
-import { expect } from "chai";
-import { set, InsertMode } from "../../lib/set";
+import {expect} from "chai";
+import {InsertMode, set} from "../../lib/set";
 
 /*
     ??? Syntax
@@ -155,6 +155,35 @@ describe("set", () => {
                 InsertMode.REPLACE_ITEMS
             );
             expect(result).to.deep.eq({ list: [1, { value: "t" }, 3] });
+        });
+
+        it("should merge into object nested in single-level array", () => {
+            const result = set(
+                [{ text: 'A' }, { text: 'B' }],
+                "#/1",
+                { additionalText: 'C' }
+            );
+            expect(result).to.deep.eq([{ text: 'A' }, { text: 'B', additionalText: 'C' } ]);
+        });
+
+        it("should replace into object nested in single-level array", () => {
+            const result = set(
+                [{ text: 'A' }, { text: 'B' }],
+                "#/1",
+                { additionalText: 'C' },
+                InsertMode.REPLACE_ITEMS
+            );
+            expect(result).to.deep.eq([{ text: 'A' }, { additionalText: 'C' } ])
+        });
+
+        it("should insert into object nested in single-level array", () => {
+            const result = set(
+                [{ text: 'A' }, { text: 'B' }],
+                "#/1",
+                { additionalText: 'C' },
+                InsertMode.INSERT_ITEMS
+            );
+            expect(result).to.deep.eq([{ text: 'A' }, { additionalText: 'C' }, { text: 'B' } ])
         });
 
         it("should merge into object nested in multi-level array", () => {

--- a/test/unit/set.test.ts
+++ b/test/unit/set.test.ts
@@ -156,6 +156,35 @@ describe("set", () => {
             );
             expect(result).to.deep.eq({ list: [1, { value: "t" }, 3] });
         });
+
+        it("should merge into object nested in multi-level array", () => {
+            const result = set(
+                [[{ text: 'A' }, { text: 'B' } ]],
+                "#/0/1",
+                { additionalText: 'C' }
+            );
+            expect(result).to.deep.eq([[{ text: 'A' }, { text: 'B', additionalText: 'C' } ]]);
+        });
+
+        it("should replace into object nested in multi-level array", () => {
+            const result = set(
+                [[{ text: 'A' }, { text: 'B' } ]],
+                "#/0/1",
+                { additionalText: 'C' },
+                InsertMode.REPLACE_ITEMS
+            );
+            expect(result).to.deep.eq([[{ text: 'A' }, { additionalText: 'C' } ]]);
+        });
+
+        it("should insert into object nested in multi-level array", () => {
+            const result = set(
+                [[{ text: 'A' }, { text: 'B' } ]],
+                "#/0/1",
+                { additionalText: 'C' },
+                InsertMode.INSERT_ITEMS
+            );
+            expect(result).to.deep.eq([[{ text: 'A' }, { additionalText: 'C' }, { text: 'B' } ]]);
+        });
     });
 
     describe("queries", () => {


### PR DESCRIPTION
PR makes the following changes:

1. Object array items which are `set` with another object are merged. Previous behaviour was to do nothing. There is a [comment indicating merging was perhaps being considered](https://github.com/sagold/json-query/blob/main/lib/set.ts#L64) but the action was left unhandled.
2. Previously the `set` function could clear items adjacent to the element being set. This feels undesirable as the set operation is altering part of the object outside of the path that is being targeted. That _should_ no longer happen.

The changes don't break any of the existing tests which lead me to believe they just haven't been accomodated for. Below shows the newly added tests which fail when run against the code in the `main` branch.

```
  1) set
       array
         should merge into object nested in single-level array:

      AssertionError: expected [ { text: 'A' }, { text: 'B' } ] to deeply equal [ { text: 'A' }, …(1) ]
      + expected - actual

         {
           "text": "A"
         }
         {
      +    "additionalText": "C"
           "text": "B"
         }
       ]

      at Context.<anonymous> (test/unit/set.test.ts:166:36)
      at processImmediate (node:internal/timers:476:21)

  2) set
       array
         should merge into object nested in multi-level array:

      AssertionError: expected [ [ undefined, …(1) ] ] to deeply equal [ [ { text: 'A' }, …(1) ] ]
      + expected - actual

       [
         [
           {
      +      "text": "A"
      +    }
      +    {
             "additionalText": "C"
      +      "text": "B"
           }
         ]
       ]

      at Context.<anonymous> (test/unit/set.test.ts:195:36)
      at processImmediate (node:internal/timers:476:21)

  3) set
       array
         should replace into object nested in multi-level array:

      AssertionError: expected [ [ undefined, …(1) ] ] to deeply equal [ [ { text: 'A' }, …(1) ] ]
      + expected - actual

       [
         [
           {
      +      "text": "A"
      +    }
      +    {
             "additionalText": "C"
           }
         ]
       ]

      at Context.<anonymous> (test/unit/set.test.ts:205:36)
      at processImmediate (node:internal/timers:476:21)

  4) set
       array
         should insert into object nested in multi-level array:

      AssertionError: expected [ [ undefined, …(1) ], …(1) ] to deeply equal [ [ { text: 'A' }, …(2) ] ]
      + expected - actual

       [
         [
           {
      -      "additionalText": "C"
      +      "text": "A"
           }
      -  ]
      -  [
           {
      -      "text": "A"
      +      "additionalText": "C"
           }
           {
             "text": "B"
           }

      at Context.<anonymous> (test/unit/set.test.ts:215:36)
      at processImmediate (node:internal/timers:476:21)
```

Hopefully this can be accepted. Please let me know if anything more is needed to get this merged and released.

Thanks!